### PR TITLE
fix some documentation

### DIFF
--- a/example-card-integration/README.md
+++ b/example-card-integration/README.md
@@ -1,6 +1,6 @@
 # Lucid / Example card integration
 
-This repository contains the source for an example card integration built on Lucid's extensibility platform. This integration is based on the card integration walkthorugh presented [here](https://developer.lucid.co/extension-api/#lucid-card-integrations). This integration does not connect to an actual external data source and instead mocks the reponses one would get from such a source.
+This repository contains the source for an example card integration built on Lucid's extensibility platform. This integration is based on the card integration walkthrough presented [here](https://developer.lucid.co/extension-api/#lucid-card-integrations). This integration does not connect to an actual external data source and instead mocks the responses one would get from such a source.
 
 ## Getting started
 
@@ -46,7 +46,7 @@ With the OAuth client id, and client secret for your Smartsheet application, you
 
 Now you're ready to bundle, upload and install your extension by following the rest of the directions [here](https://developer.lucid.co/extension-api/#bundle-your-package-for-upload).
 
-For testing purposes you can run the data connector as shown above but it will now need to be at a publically reachable address.
+For testing purposes you can run the data connector as shown above but it will now need to be at a publicly reachable address.
 When you release your extension you will want to serve your data connector in a way that doesn't use the express debug server.
 
 More information about running a data connector can be found [here](https://developer.lucid.co/extension-api/#expose-a-url-for-your-data-connector).
@@ -58,18 +58,21 @@ The code is organized into the following folders:
 ├── editorextensions
 │   └── example-card-integration
 │       └── src
+├── shapelibraries
 ├── common
-├── common
+├── data
 └── data-connector
     ├── actions
     ├── schema
 ```
 
-`/asana-extension-package` contains the editor extension used for the integration, including the package manifest, the extension source code, and any shape libraries defined by the extension (in this case none).
+`/editorextensions` contains the extension source code.
+
+`/shapelibraries` contains any shape libraries defined by the extension (in this case none).
 
 `/common` contains code relevant to both the editor extension users will interact with, as well as the data connector.
 
 `/data` contains code sample data that this integration uses to demo the capability of of Lucid's card framework.
 
 `/data-connector` contains the code for the data connector leveraged by the editor extension. 
-The data connector handles the responsiblity of fetching and formatting the sample data, as well as handling the creation of new sample tasks. You can learn more about data connectors [here](https://developer.lucid.co/extension-api/#connecting-to-external-data).
+The data connector handles the responsibility of fetching and formatting the sample data, as well as handling the creation of new sample tasks. You can learn more about data connectors [here](https://developer.lucid.co/extension-api/#connecting-to-external-data).


### PR DESCRIPTION
This PR changes some documentation in `example-card-integration`. (some minor spelling & the Folder / file structure)